### PR TITLE
Post route with AppSignal instrumentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,14 @@ app.get("/", (req, res) => {
 });
 
 app.post("/login",(req, res) => {
-  console.log(req.body);
-  var user_name = req.body.user;
-  var password = req.body.password;
-  console.log("User name = "+user_name+", password is "+password);
+  const tracer = appsignal.tracer();
+  const span = tracer.currentSpan();
+  console.log("path", req.url);
+  // Use AppSignal tags to add more context to the sample: https://docs.appsignal.com/guides/custom-data/tagging-request.html#node-js
+  span.set("path", req.url);
+
+  // Use AppSignal sample data to add metadata to the sample: https://docs.appsignal.com/guides/custom-data/sample-data.html
+  span.setSampleData("custom_data", req.body);
   res.end("Logged in");
   });
 

--- a/index.js
+++ b/index.js
@@ -1,16 +1,28 @@
 const { app, appsignal } = require("./express");
 // const https = require('https')
 const { expressErrorHandler } = require("@appsignal/express");
+const bodyParser = require("body-parser");
 
 const adminRoutes = require("./routes/admin.routes");
 const userRoutes = require("./routes/user.routes");
+
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 app.use("/admin", adminRoutes);
 app.use("/user", userRoutes);
 app.get("/", (req, res) => {
   res.send("Hello");
 });
 
-app.get("/error", (req, res) => {
+app.post("/login",(req, res) => {
+  console.log(req.body);
+  var user_name = req.body.user;
+  var password = req.body.password;
+  console.log("User name = "+user_name+", password is "+password);
+  res.end("Logged in");
+  });
+
+  app.get("/error", (req, res) => {
   const tracer = appsignal.tracer();
   try {
     throw new Error("Oh no!");

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "dependencies": {
         "@appsignal/express": "1.0.28",
         "@appsignal/nodejs": "2.3.4",
-        "express": "*",
+        "body-parser": "^1.20.0",
+        "express": "^4.18.0",
         "pg": "^8.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "@appsignal/express": "1.0.28",
     "@appsignal/nodejs": "2.3.4",
-    "express": "*",
+    "body-parser": "^1.20.0",
+    "express": "^4.18.0",
     "pg": "^8.5.1"
   },
   "scripts": {


### PR DESCRIPTION
This PR adds a POST route and shows how to use AppSignal`s tags and sample data to add more context to the sample.